### PR TITLE
Translate Russian comments to English

### DIFF
--- a/src/omr_lab/common/logging.py
+++ b/src/omr_lab/common/logging.py
@@ -19,8 +19,8 @@ def _get_json_processors() -> list:
 
 def setup_logging(level: int = logging.INFO) -> None:
     """
-    Консольное JSON-логирование (идемпотентно).
-    Для логов в файл вызови add_file_logging().
+    Console JSON logging (idempotent).
+    Call add_file_logging() to log to a file.
     """
     logging.basicConfig(level=level, format="%(message)s")
     structlog.configure(
@@ -32,8 +32,8 @@ def setup_logging(level: int = logging.INFO) -> None:
 
 def add_file_logging(log_file: Path, level: int = logging.INFO) -> None:
     """
-    Подключает RotatingFileHandler, который пишет JSON-строки.
-    Избегаем дублирования по совпадению baseFilename.
+    Attaches a RotatingFileHandler that writes JSON strings.
+    Avoid duplicate handlers by matching baseFilename.
     """
     log_file.parent.mkdir(parents=True, exist_ok=True)
     root_logger = logging.getLogger()

--- a/src/omr_lab/common/runctx.py
+++ b/src/omr_lab/common/runctx.py
@@ -34,8 +34,8 @@ def _env_info() -> dict[str, Any]:
     pkgs: dict[str, str] = {}
     try:
         for dist in importlib_metadata.distributions():
-            # PackageMetadata у дистрибуции ведёт себя как mapping, но типы mypy консервативны.
-            # Надёжно через try/except, без .get().
+            # PackageMetadata of a distribution behaves like a mapping, but mypy types are conservative.
+            # Use try/except for reliability instead of .get().
             try:
                 name = dist.metadata["Name"]  # type: ignore[index]
             except Exception:
@@ -45,7 +45,7 @@ def _env_info() -> dict[str, Any]:
             version = dist.version or ""
             pkgs[name] = version
     except Exception:
-        # В случае проблем со сбором метаданных просто возвращаем то, что успели собрать.
+        # If collecting metadata fails, just return whatever was gathered.
         pass
 
     return {

--- a/src/omr_lab/data/normalize.py
+++ b/src/omr_lab/data/normalize.py
@@ -9,11 +9,11 @@ from omr_lab.common.ir import LyricsToken, MeasureIR, NoteEvent, PartIR, ScoreIR
 
 
 def _coerce_to_score(obj: Any) -> stream.Score:
-    """Приводим результат converter.parse к Score (обрабатываем Opus/Part)."""
+    """Convert the result of converter.parse to Score (handle Opus/Part)."""
     if isinstance(obj, stream.Score):
         return obj
     if isinstance(obj, stream.Opus):
-        # Берём первый Score из Opus (чаще всего один)
+        # Take the first Score from the Opus (often only one)
         if obj.scores:
             return obj.scores[0]
         sc = stream.Score()
@@ -25,7 +25,7 @@ def _coerce_to_score(obj: Any) -> stream.Score:
         sc = stream.Score()
         sc.insert(0, obj)
         return sc
-    # Фоллбек: пытаемся собрать Score из доступных Part
+    # Fallback: try to build a Score from available Parts
     sc = stream.Score()
     parts = getattr(obj, "parts", None)
     if parts:
@@ -66,7 +66,7 @@ def musicxml_to_ir(path: Path) -> ScoreIR:
     for p_idx, p in enumerate(sc.parts):
         measures_ir: list[MeasureIR] = []
         flat: stream.Stream = p.flat  # type: ignore[assignment]
-        # measureNumber может быть None → фильтруем и приводим к int
+        # measureNumber may be None → filter and cast to int
         measure_numbers = sorted(
             {
                 int(mn)
@@ -158,7 +158,7 @@ def normalize_folder(in_dir: Path, out_dir: Path) -> int:
             try:
                 ir = musicxml_to_ir(p)
                 out_path = out_dir / (p.stem + ".json")
-                # Pydantic v2: используем json.dumps(c.dict())
+                # Pydantic v2: use json.dumps(c.dict())
                 out_path.write_text(
                     json.dumps(ir.model_dump(), indent=2, ensure_ascii=False), encoding="utf-8"
                 )

--- a/src/omr_lab/data/synth.py
+++ b/src/omr_lab/data/synth.py
@@ -37,7 +37,7 @@ def _attach_lyrics_to_notes(nlist: list[note.Note], words: list[str]) -> None:
         if i < len(syls):
             s, syl = syls[i]
             lyr = Lyric(text=s)
-            # допустимые значения: "single", "begin", "middle", "end"
+            # allowed values: "single", "begin", "middle", "end"
             lyr.syllabic = syl  # type: ignore[assignment]
             n.lyrics.append(lyr)
 
@@ -52,7 +52,7 @@ def synth_one(out_musicxml: Path, words: list[str] | None = None, measures: int 
     for _m in range(measures):
         for _q in range(4):
             n = note.Note(random.choice(["C4", "D4", "E4", "F4", "G4", "A4", "B4"]))
-            n.duration = duration.Duration(1.0)  # четверть
+            n.duration = duration.Duration(1.0)  # quarter note
             notes.append(n)
             p.append(n)
 

--- a/src/omr_lab/services/cli.py
+++ b/src/omr_lab/services/cli.py
@@ -41,7 +41,7 @@ OPT_OUT_SUMMARY = typer.Option(Path("experiments/reports/summary"), help="Output
 ARG_SOURCE = typer.Argument(..., help="Folder with metrics to summarize into a report.")
 OPT_OUT_FINAL = typer.Option(Path("experiments/reports/final"), help="Output folder.")
 
-# Новые параметры для data-команд
+# New parameters for data commands
 ARG_MXL_IN = typer.Argument(..., help="Folder with MusicXML files.")
 ARG_IR_OUT = typer.Argument(..., help="Folder to write IR JSON.")
 OPT_SYNTH_OUT = typer.Option(

--- a/src/omr_lab/services/pipeline_registry.py
+++ b/src/omr_lab/services/pipeline_registry.py
@@ -10,7 +10,7 @@ PipelineFn = Callable[[Iterable[Path], Path, AppConfig | None], None]
 def get_registry() -> dict[str, PipelineFn]:
     return {
         "rules": run_rules_pipeline,
-        # "hybrid": run_hybrid_pipeline, # добавим позже
-        # "ai": run_ai_pipeline, # добавим позже
+        # "hybrid": run_hybrid_pipeline, # to be added later
+        # "ai": run_ai_pipeline, # to be added later
         # "baseline": run_baseline_pipeline
     }

--- a/src/omr_lab/services/prepare.py
+++ b/src/omr_lab/services/prepare.py
@@ -15,9 +15,9 @@ def prepare_dataset(input_path: Path, output_path: Path) -> int:
 
     items: Iterable[Path]
     if input_path.is_dir():
-        items = input_path.rglob("*")  # iterable из Path
+        items = input_path.rglob("*")  # iterable of Path
     else:
-        items = [input_path]  # список тоже Iterable[Path]
+        items = [input_path]  # list is also Iterable[Path]
 
     for p in items:
         if p.is_file() and p.suffix.lower() in SUPPORTED_EXT:


### PR DESCRIPTION
## Summary
- translate Russian CLI comment for new data commands
- replace Russian comments in synthesis, normalization, pipeline registry, logging, run context, and data preparation modules with English equivalents

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4c9fb25dc83219f1d192c73504e3b